### PR TITLE
Fixed navbar for mobile

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -17,13 +17,13 @@ export default () => (
         <a href="#more">More</a>
       </li>
       <li>
-        <a id="app-button" href="https://governance.mstable.org">
-          System Governance
+        <a id="app-button" href="https://app.mstable.org">
+          Go to App
         </a>
       </li>
       <li>
-        <a id="app-button" href="https://app.mstable.org">
-          Go to App
+        <a id="app-button" href="https://governance.mstable.org">
+          Governance
         </a>
       </li>
     </ul>

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -245,6 +245,10 @@ footer
 @media (max-width: 550px)
 	nav
 		position static
+	ul
+		justify-content: center;
+		flex: 3; 
+
 	#header
 		margin-top 150px
 		max-height 400px

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -90,6 +90,7 @@ nav
 	ul
 		display flex
 		align-items center
+		flex-flow: wrap;
 		li
 			margin-left 1.5em
 


### PR DESCRIPTION
The mstable logo was not being displayed on mobile in the navbar and the list was overflowing the navbar so I pushed a small fix