### PR TITLE
fix: mstable apps links

### DIFF
--- a/src/components/home/Adverts.tsx
+++ b/src/components/home/Adverts.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import styled from 'styled-components'
 
+import { MTA_BURN_APP_LINK, YIELD_APP_LINK } from '../../constants'
 import { Card, CardActions, CardContent, CardHeader } from '../Card'
 import { LinkButton } from '../CTA'
 
@@ -33,7 +34,7 @@ export const Adverts: FC = () => (
           <p>Unlock maximum returns with Meta Harvester, the vault that redefines DeFi yield farming. </p>
         </CardContent>
         <CardActions>
-          <LinkButton href="https://yield.mstable.app/vault/0x9c6de13d4648a6789017641f6b1a025816e66228" highlight external={false}>
+          <LinkButton href={`${YIELD_APP_LINK}/vault/0x9c6de13d4648a6789017641f6b1a025816e66228`} highlight external={false}>
             Meta Harvester
           </LinkButton>
         </CardActions>
@@ -69,7 +70,7 @@ export const Adverts: FC = () => (
           <p>Burn MTA to receive stablecoin yield on Optimism. Swap fixed at $0.0318 USD / MTA.</p>
         </CardContent>
         <CardActions>
-          <LinkButton href="https://withdraw.mstable.app/burn" external={false}>
+          <LinkButton href={MTA_BURN_APP_LINK} external={false}>
             MTA Buyback
           </LinkButton>
         </CardActions>

--- a/src/components/home/Products.tsx
+++ b/src/components/home/Products.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import styled from 'styled-components'
 
+import { WITHDRAW_APP_LINK, YIELD_APP_LINK } from '../../constants'
 import { Card, CardActions, CardContent, CardHeader } from '../Card'
 import { LinkButton } from '../CTA'
 
@@ -28,7 +29,7 @@ export const Products: FC = () => {
           <p>New yield products to earn best in market yields.</p>
         </CardContent>
         <CardActions>
-          <LinkButton href="https://yield.mstable.app" highlight external={false}>
+          <LinkButton href={YIELD_APP_LINK} highlight external={false}>
             mStable Yield App
           </LinkButton>
         </CardActions>
@@ -41,7 +42,7 @@ export const Products: FC = () => {
           <p>Withdraw from your legacy mStable product positions.</p>
         </CardContent>
         <CardActions>
-          <LinkButton href="https://withdraw.mstable.app" external={false}>
+          <LinkButton href={WITHDRAW_APP_LINK} external={false}>
             Legacy Support
           </LinkButton>
         </CardActions>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 
-import { MTA_BUY_LINK } from '../../constants'
+import { MTA_BUY_LINK, YIELD_APP_LINK } from '../../constants'
 import DefiPulse from '../../images/social/defi-pulse.svg'
 import Discord from '../../images/social/discord.svg'
 import Email from '../../images/social/email.svg'
@@ -238,7 +238,7 @@ export const Footer: FC = () => {
         <Top>
           <div>
             <Header>Protocol</Header>
-            <ExternalLinkChevron href="https://yield.mstable.app/">App</ExternalLinkChevron>
+            <ExternalLinkChevron href={YIELD_APP_LINK}>App</ExternalLinkChevron>
             <ExternalLinkChevron href="https://docs.mstable.org/">Documentation</ExternalLinkChevron>
             <ExternalLinkChevron href="https://developers.mstable.org/">Developers</ExternalLinkChevron>
             <LinkChevron href="/save">About Save</LinkChevron>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,6 +6,7 @@ import { useToggle, useWindowScroll } from 'react-use'
 import useMeasure from 'react-use/lib/useMeasure'
 import styled from 'styled-components'
 
+import { WITHDRAW_APP_LINK, YIELD_APP_LINK } from '../../constants'
 import { ReactComponent as LogoSvg } from '../../images/mstable-logo.svg'
 import { Colors, Constants } from '../../theme'
 import { LinkButton } from '../CTA'
@@ -95,13 +96,13 @@ const urls: {
 }[] = [
   {
     title: 'Open App',
-    href: 'https://yield.mstable.app/',
+    href: YIELD_APP_LINK,
     isButton: true,
     highlight: true,
   },
   {
     title: 'Legacy Support',
-    href: 'https://withdraw.mstable.app',
+    href: WITHDRAW_APP_LINK,
     isButton: true,
   },
 ]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,7 @@ export const STATS_API_ENDPOINT = 'https://api.mstable.org'
 
 export const MTA_BUY_LINK =
   'https://app.bancor.network/eth/swap?from=0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C&to=0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2'
+
+export const WITHDRAW_APP_LINK = 'https://withdraw.mstable.org'
+export const MTA_BURN_APP_LINK = `${WITHDRAW_APP_LINK}/burn`
+export const YIELD_APP_LINK = 'https://yield.mstable.org'


### PR DESCRIPTION
Updated yield app and withdraw app links to point to `.org` instead of `.app`